### PR TITLE
Move build-std argument after the subcommand to fix clippy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,16 +126,18 @@ pub fn make_cargo_build_command(
         .arg("--target")
         .arg("armv6k-nintendo-3ds")
         .arg("--message-format")
-        .arg(message_format)
-        .args(args)
-        .stdout(Stdio::piped())
-        .stdin(Stdio::inherit())
-        .stderr(Stdio::inherit());
+        .arg(message_format);
 
     if !sysroot.join("lib/rustlib/armv6k-nintendo-3ds").exists() {
         eprintln!("No pre-build std found, using build-std");
         command.arg("-Z").arg("build-std");
     }
+
+    command
+        .args(args)
+        .stdout(Stdio::piped())
+        .stdin(Stdio::inherit())
+        .stderr(Stdio::inherit());
 
     command
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,11 +113,6 @@ pub fn make_cargo_build_command(
     let sysroot = find_sysroot();
     let mut command = Command::new(cargo);
 
-    if !sysroot.join("lib/rustlib/armv6k-nintendo-3ds").exists() {
-        eprintln!("No pre-build std found, using build-std");
-        command.arg("-Z").arg("build-std");
-    }
-
     let cmd = match cmd {
         CargoCommand::Build | CargoCommand::Run => "build",
         CargoCommand::Test => "test",
@@ -136,6 +131,11 @@ pub fn make_cargo_build_command(
         .stdout(Stdio::piped())
         .stdin(Stdio::inherit())
         .stderr(Stdio::inherit());
+
+    if !sysroot.join("lib/rustlib/armv6k-nintendo-3ds").exists() {
+        eprintln!("No pre-build std found, using build-std");
+        command.arg("-Z").arg("build-std");
+    }
 
     command
 }


### PR DESCRIPTION
This fixes `cargo +nightly 3ds clippy`. See this thread:
https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/-Zbuild-std.20and.20clippy.3F/near/290622458