### PR TITLE
Upgrade to clap4, add extra args and help strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 cargo_metadata = "0.14.0"
 rustc_version = "0.4.0"
 semver = "1.0.10"
-serde = {version = "1.0.139", features = ['derive']}
+serde = { version = "1.0.139", features = ['derive'] }
 tee = "0.1.0"
 toml = "0.5.6"
-clap = { version = "3.2.12", features = ["derive"]}
+clap = { version = "4.0.15", features = ["derive", "wrap_help"] }

--- a/README.md
+++ b/README.md
@@ -1,26 +1,97 @@
 # cargo-3ds
+
 Cargo command to work with Nintendo 3DS project binaries. Based on cargo-psp.
 
-# Usage
+## Usage
+
 Use the nightly toolchain to build 3DS apps (either by using `rustup override nightly` for the project directory or by adding `+nightly` in the `cargo` invocation).
 
-Available commands:
-```
-    build           build a 3dsx executable.
-    run             build a 3dsx executable and send it to a device with 3dslink.
-    test            build a 3dsx executable from unit/integration tests and send it to a device.
-    <cargo-command> execute some other Cargo command with 3ds options configured (ex. check or clippy).
-```
-    
-Additional arguments will be passed through to `<cargo-command>`. Some that are supported include:
-```
-    [build | run | test] --release
-    test --no-run
-```
-    
-Other flags and commands may work, but haven't been tested.
+```txt
+Commands:
+  build
+          Builds an executable suitable to run on a 3DS (3dsx)
+  run
+          Builds an executable and sends it to a device with `3dslink`
+  test
+          Builds a test executable and sends it to a device with `3dslink`
+  help
+          Print this message or the help of the given subcommand(s)
 
-# Examples
-`cargo 3ds build` \
-`cargo 3ds run --release` \
-`cargo 3ds test --no-run`
+Options:
+  -h, --help
+          Print help information (use `-h` for a summary)
+
+  -V, --version
+          Print version information
+```
+
+Additional arguments will be passed through to the given subcommand.
+See [passthrough arguments](#passthrough-arguments) for more details.
+
+It is also possible to pass any other `cargo` command (e.g. `doc`, `check`),
+and all its arguments will be passed through directly to `cargo` unmodified,
+with the proper `RUSTFLAGS` and `--target` set for the 3DS target.
+
+### Basic Examples
+
+* `cargo 3ds build`
+* `cargo 3ds check --verbose`
+* `cargo 3ds run --release --example foo`
+* `cargo 3ds test --no-run`
+
+### Running executables
+
+`cargo 3ds test` and `cargo 3ds run` use the `3dslink` tool to send built
+executables to a device, and thus accept specific related arguments that correspond
+to `3dslink` arguments:
+
+```txt
+-a, --address <ADDRESS>
+      Specify the IP address of the device to send the executable to.
+
+      Corresponds to 3dslink's `--address` arg, which defaults to automatically finding the device.
+
+-0, --argv0 <ARGV0>
+      Set the 0th argument of the executable when running it. Corresponds to 3dslink's `--argv0` argument
+
+-s, --server
+      Start the 3dslink server after sending the executable. Corresponds to 3dslink's `--server` argument
+
+  --retries <RETRIES>
+      Set the number of tries when connecting to the device to send the executable. Corresponds to 3dslink's `--retries` argument
+```
+
+### Passthrough Arguments
+
+Due to the way `cargo-3ds`, `cargo`, and `3dslink` parse arguments, there is
+unfortunately some complexity required when invoking an executable with arguments.
+
+All unrecognized arguments beginning with a dash (e.g. `--release`, `--features`,
+etc.) will be passed through to `cargo` directly.
+
+> **NOTE:** arguments for [running executables](#running-executables) must be
+> specified *before* other unrecognized `cargo` arguments. Otherwise they will
+> be treated as passthrough arguments which will most likely fail the resulting
+> `cargo` command.
+
+An optional `--` may be used to explicitly pass subsequent args to `cargo`, including
+arguments to pass to the executable itself. To separate `cargo` arguments from
+executable arguments, *another* `--` can be used. For example:
+
+* `cargo 3ds run -- -- xyz`
+
+    Builds an executable and send it to a device to run it with the argument `xyz`.
+
+* `cargo 3ds test --address 192.168.0.2 -- -- --test-arg 1`
+
+  Builds a test executable and attempts to send it to a device with the
+  address `192.168.0.2` and run it using the arguments `["--test-arg", "1"]`.
+
+* `cargo 3ds test --address 192.168.0.2 --verbose -- --test-arg 1`
+
+  Build a test executable with `cargo test --verbose`, and attempts to send
+  it to a device with the address `192.168.0.2` and run it using the arguments
+  `["--test-arg", "1"]`.
+
+  This works without two `--` instances because `--verbose` begins the set of
+  `cargo` arguments and ends the set of 3DS-specific arguments.

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,10 +1,7 @@
-// TODO: docstrings for everything!!!
-
 use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser, Debug)]
-#[command(name = "cargo")]
-#[command(bin_name = "cargo")]
+#[command(name = "cargo", bin_name = "cargo")]
 pub enum Cargo {
     #[command(name = "3ds")]
     Input(Input),
@@ -13,20 +10,44 @@ pub enum Cargo {
 #[derive(Args, Debug)]
 #[command(version, about)]
 pub struct Input {
-    /// The cargo command to run. This command will be forwarded to the real
-    /// `cargo` with the appropriate arguments for a 3DS executable.
     #[command(subcommand)]
-    pub cmd: CargoCommand,
+    pub cmd: CargoCmd,
+}
 
-    /// Don't actually run any commands, just echo them to the console.
-    /// This is mostly intended for testing.
-    #[arg(long, hide = true)]
-    pub dry_run: bool,
+/// The cargo command to run. This command will be forwarded to the real
+/// `cargo` with the appropriate arguments for a 3DS executable.
+///
+/// If another command is passed which is not recognized, it will be passed
+/// through unmodified to `cargo` with RUSTFLAGS set for the 3DS.
+#[derive(Subcommand, Debug)]
+#[command(allow_external_subcommands = true)]
+pub enum CargoCmd {
+    /// Builds an executable suitable to run on a 3DS (3dsx).
+    Build(CargoArgs),
 
+    /// Builds an executable and sends it to a device with `3dslink`.
+    Run(Run),
+
+    /// Builds a test executable and sends it to a device with `3dslink`.
+    ///
+    /// This can be used with `--test` for integration tests, or `--lib` for
+    /// unit tests (which require a custom test runner).
+    Test(Test),
+
+    // NOTE: it seems docstring + name for external subcommands are not rendered
+    // in help, but we might as well set them here in case a future version of clap
+    // does include them in help text.
+    /// Run any other `cargo` command with RUSTFLAGS set for the 3DS.
+    #[command(external_subcommand, name = "COMMAND")]
+    Passthrough(Vec<String>),
+}
+
+#[derive(Args, Debug)]
+pub struct CargoArgs {
     /// Pass additional options through to the `cargo` command.
     ///
     /// To pass flags that start with `-`, you must use `--` to separate `cargo 3ds`
-    /// options from cargo options. All args after `--` will be passed through
+    /// options from cargo options. Any argument after `--` will be passed through
     /// to cargo unmodified.
     ///
     /// If one of the arguments is itself `--`, the args following that will be
@@ -36,50 +57,31 @@ pub struct Input {
     ///
     /// > cargo 3ds run -- -- arg1 arg2
     #[arg(trailing_var_arg = true)]
+    #[arg(allow_hyphen_values = true)]
     #[arg(global = true)]
-    cargo_options: Vec<String>,
+    #[arg(name = "CARGO_ARGS")]
+    args: Vec<String>,
 }
 
-#[derive(Subcommand, Debug)]
-pub enum CargoCommand {
-    /// Builds an executable suitable to run on a 3DS (3dsx).
-    Build,
-    /// Equivalent to `cargo check`.
-    Check,
-    /// Equivalent to `cargo clippy`.
-    Clippy,
-    /// Equivalent to `cargo doc`.
-    Doc,
-    /// Builds an executable and sends it to a device with `3dslink`.
-    Run(Run),
-    /// Builds a test executable and sends it to a device with `3dslink`.
-    ///
-    /// This can be used with `--test` for integration tests, or `--lib` for
-    /// unit tests (which require a custom test runner).
-    Test(Test),
-    //
-    // TODO: this doesn't seem to work for some reason...
-    // #[command(external_subcommand)]
-    // Other(Vec<String>),
-}
-
-#[derive(Args, Debug)]
+#[derive(Parser, Debug)]
 pub struct Test {
     /// If set, the built executable will not be sent to the device to run it.
     #[arg(long)]
     pub no_run: bool,
+
+    // The test command uses a superset of the same arguments as Run.
     #[command(flatten)]
     pub run_args: Run,
 }
 
-#[derive(Args, Debug)]
+#[derive(Parser, Debug)]
 pub struct Run {
     /// Specify the IP address of the device to send the executable to.
     ///
     /// Corresponds to 3dslink's `--address` arg, which defaults to automatically
     /// finding the device.
     #[arg(long, short = 'a')]
-    pub address: Option<String>,
+    pub address: Option<std::net::Ipv4Addr>,
 
     /// Set the 0th argument of the executable when running it. Corresponds to
     /// 3dslink's `--argv0` argument.
@@ -88,7 +90,7 @@ pub struct Run {
 
     /// Start the 3dslink server after sending the executable. Corresponds to
     /// 3dslink's `--server` argument.
-    #[arg(long, short = 's')]
+    #[arg(long, short = 's', default_value_t = false)]
     pub server: bool,
 
     /// Set the number of tries when connecting to the device to send the executable.
@@ -96,9 +98,13 @@ pub struct Run {
     // Can't use `short = 'r'` because that would conflict with cargo's `--release/-r`
     #[arg(long)]
     pub retries: Option<usize>,
+
+    // Passthrough cargo options.
+    #[command(flatten)]
+    pub cargo_args: CargoArgs,
 }
 
-impl Input {
+impl CargoArgs {
     /// Get the args to be passed to the executable itself (not `cargo`).
     pub fn cargo_opts(&self) -> &[String] {
         self.split_args().0
@@ -110,15 +116,31 @@ impl Input {
     }
 
     fn split_args(&self) -> (&[String], &[String]) {
-        if let Some(split) = self.cargo_options.iter().position(|arg| arg == "--") {
-            let split = if &self.cargo_options[split] == "--" {
+        if let Some(split) = self
+            .args
+            .iter()
+            .position(|s| s == "--" || !s.starts_with('-'))
+        {
+            let split = if self.args[split] == "--" {
                 split + 1
             } else {
                 split
             };
-            self.cargo_options.split_at(split)
+            self.args.split_at(split)
         } else {
-            (&self.cargo_options[..], &[])
+            (&self.args[..], &[])
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use clap::CommandFactory;
+
+    #[test]
+    fn verify_app() {
+        Cargo::command().debug_assert();
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -23,7 +23,7 @@ pub struct Input {
 #[command(allow_external_subcommands = true)]
 pub enum CargoCmd {
     /// Builds an executable suitable to run on a 3DS (3dsx).
-    Build(CargoArgs),
+    Build(RemainingArgs),
 
     /// Builds an executable and sends it to a device with `3dslink`.
     Run(Run),
@@ -43,7 +43,7 @@ pub enum CargoCmd {
 }
 
 #[derive(Args, Debug)]
-pub struct CargoArgs {
+pub struct RemainingArgs {
     /// Pass additional options through to the `cargo` command.
     ///
     /// To pass flags that start with `-`, you must use `--` to separate `cargo 3ds`
@@ -101,12 +101,74 @@ pub struct Run {
 
     // Passthrough cargo options.
     #[command(flatten)]
-    pub cargo_args: CargoArgs,
+    pub cargo_args: RemainingArgs,
 }
 
-impl CargoArgs {
+impl CargoCmd {
+    /// Whether or not this command should build a 3DSX executable file.
+    pub fn should_build_3dsx(&self) -> bool {
+        matches!(self, Self::Build(_) | Self::Run(_) | Self::Test(_))
+    }
+
+    /// Whether or not the resulting executable should be sent to the 3DS with
+    /// `3dslink`.
+    pub fn should_link_to_device(&self) -> bool {
+        match self {
+            CargoCmd::Test(test) => !test.no_run,
+            CargoCmd::Run(_) => true,
+            _ => false,
+        }
+    }
+
+    pub const DEFAULT_MESSAGE_FORMAT: &str = "json-render-diagnostics";
+
+    pub fn extract_message_format(&mut self) -> Result<Option<String>, String> {
+        Self::extract_message_format_from_args(match self {
+            CargoCmd::Build(args) => &mut args.args,
+            CargoCmd::Run(run) => &mut run.cargo_args.args,
+            CargoCmd::Test(test) => &mut test.run_args.cargo_args.args,
+            CargoCmd::Passthrough(args) => args,
+        })
+    }
+
+    fn extract_message_format_from_args(
+        cargo_args: &mut Vec<String>,
+    ) -> Result<Option<String>, String> {
+        // Checks for a position within the args where '--message-format' is located
+        if let Some(pos) = cargo_args
+            .iter()
+            .position(|s| s.starts_with("--message-format"))
+        {
+            // Remove the arg from list so we don't pass anything twice by accident
+            let arg = cargo_args.remove(pos);
+
+            // Allows for usage of '--message-format=<format>' and also using space separation.
+            // Check for a '=' delimiter and use the second half of the split as the format,
+            // otherwise remove next arg which is now at the same position as the original flag.
+            let format = if let Some((_, format)) = arg.split_once('=') {
+                format.to_string()
+            } else {
+                // Also need to remove the argument to the --message-format option
+                cargo_args.remove(pos)
+            };
+
+            // Non-json formats are not supported so the executable exits.
+            if format.starts_with("json") {
+                Ok(Some(format))
+            } else {
+                Err(String::from(
+                    "error: non-JSON `message-format` is not supported",
+                ))
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl RemainingArgs {
     /// Get the args to be passed to the executable itself (not `cargo`).
-    pub fn cargo_opts(&self) -> &[String] {
+    pub fn cargo_args(&self) -> &[String] {
         self.split_args().0
     }
 
@@ -116,17 +178,8 @@ impl CargoArgs {
     }
 
     fn split_args(&self) -> (&[String], &[String]) {
-        if let Some(split) = self
-            .args
-            .iter()
-            .position(|s| s == "--" || !s.starts_with('-'))
-        {
-            let split = if self.args[split] == "--" {
-                split + 1
-            } else {
-                split
-            };
-            self.args.split_at(split)
+        if let Some(split) = self.args.iter().position(|s| s == "--") {
+            self.args.split_at(split + 1)
         } else {
             (&self.args[..], &[])
         }
@@ -142,5 +195,90 @@ mod tests {
     #[test]
     fn verify_app() {
         Cargo::command().debug_assert();
+    }
+
+    #[test]
+    fn extract_format() {
+        for (args, expected) in [
+            (&["--foo", "--message-format=json", "bar"][..], Some("json")),
+            (&["--foo", "--message-format", "json", "bar"], Some("json")),
+            (
+                &[
+                    "--foo",
+                    "--message-format",
+                    "json-render-diagnostics",
+                    "bar",
+                ],
+                Some("json-render-diagnostics"),
+            ),
+            (
+                &["--foo", "--message-format=json-render-diagnostics", "bar"],
+                Some("json-render-diagnostics"),
+            ),
+        ] {
+            let mut cmd = CargoCmd::Build(RemainingArgs {
+                args: args.iter().map(ToString::to_string).collect(),
+            });
+
+            assert_eq!(
+                cmd.extract_message_format().unwrap(),
+                expected.map(ToString::to_string)
+            );
+
+            if let CargoCmd::Build(args) = cmd {
+                assert_eq!(args.args, vec!["--foo", "bar"]);
+            } else {
+                unreachable!();
+            }
+        }
+    }
+
+    #[test]
+    fn extract_format_err() {
+        for args in [&["--message-format=foo"][..], &["--message-format", "foo"]] {
+            let mut cmd = CargoCmd::Build(RemainingArgs {
+                args: args.iter().map(ToString::to_string).collect(),
+            });
+
+            assert!(cmd.extract_message_format().is_err());
+        }
+    }
+
+    #[test]
+    fn split_run_args() {
+        struct TestParam {
+            input: &'static [&'static str],
+            expected_cargo: &'static [&'static str],
+            expected_exe: &'static [&'static str],
+        }
+
+        for param in [
+            TestParam {
+                input: &["--example", "hello-world", "--no-default-features"],
+                expected_cargo: &["--example", "hello-world", "--no-default-features"],
+                expected_exe: &[],
+            },
+            TestParam {
+                input: &["--example", "hello-world", "--", "--do-stuff", "foo"],
+                expected_cargo: &["--example", "hello-world", "--"],
+                expected_exe: &["--do-stuff", "foo"],
+            },
+            TestParam {
+                input: &["--lib", "--", "foo"],
+                expected_cargo: &["--lib", "--"],
+                expected_exe: &["foo"],
+            },
+            TestParam {
+                input: &["foo", "--", "bar"],
+                expected_cargo: &["foo", "--"],
+                expected_exe: &["bar"],
+            },
+        ] {
+            let Run { cargo_args, .. } =
+                Run::parse_from(std::iter::once(&"run").chain(param.input));
+
+            assert_eq!(cargo_args.cargo_args(), param.expected_cargo);
+            assert_eq!(cargo_args.exe_args(), param.expected_exe);
+        }
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -186,6 +186,49 @@ impl RemainingArgs {
     }
 }
 
+impl Run {
+    /// Get the args to pass to `3dslink` based on these options.
+    pub fn get_3dslink_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+
+        if let Some(address) = self.address {
+            args.extend(["--address".to_string(), address.to_string()]);
+        }
+
+        if let Some(argv0) = &self.argv0 {
+            args.extend(["--arg0".to_string(), argv0.clone()]);
+        }
+
+        if let Some(retries) = self.retries {
+            args.extend(["--retries".to_string(), retries.to_string()]);
+        }
+
+        if self.server {
+            args.push("--server".to_string());
+        }
+
+        let exe_args = self.cargo_args.exe_args();
+        if !exe_args.is_empty() {
+            // For some reason 3dslink seems to want 2 instances of `--`, one
+            // in front of all of the args like this...
+            args.extend(["--args".to_string(), "--".to_string()]);
+
+            let mut escaped = false;
+            for arg in exe_args.iter().cloned() {
+                if arg.starts_with('-') && !escaped {
+                    // And one before the first `-` arg that is passed in.
+                    args.extend(["--".to_string(), arg]);
+                    escaped = true;
+                } else {
+                    args.push(arg);
+                }
+            }
+        }
+
+        args
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/command.rs
+++ b/src/command.rs
@@ -5,14 +5,14 @@ use clap::{Args, Parser, Subcommand};
 #[derive(Parser, Debug)]
 #[command(name = "cargo")]
 #[command(bin_name = "cargo")]
-pub enum Command {
+pub enum Cargo {
     #[command(name = "3ds")]
-    Root(Root),
+    Input(Input),
 }
 
 #[derive(Args, Debug)]
 #[command(version, about)]
-pub struct Root {
+pub struct Input {
     /// The cargo command to run. This command will be forwarded to the real
     /// `cargo` with the appropriate arguments for a 3DS executable.
     #[command(subcommand)]
@@ -20,7 +20,7 @@ pub struct Root {
 
     /// Don't actually run any commands, just echo them to the console.
     /// This is mostly intended for testing.
-    #[arg(hide = true)]
+    #[arg(long, hide = true)]
     pub dry_run: bool,
 
     /// Pass additional options through to the `cargo` command.
@@ -57,9 +57,10 @@ pub enum CargoCommand {
     /// This can be used with `--test` for integration tests, or `--lib` for
     /// unit tests (which require a custom test runner).
     Test(Test),
+    //
     // TODO: this doesn't seem to work for some reason...
-    #[command(external_subcommand)]
-    Other(Vec<String>),
+    // #[command(external_subcommand)]
+    // Other(Vec<String>),
 }
 
 #[derive(Args, Debug)]
@@ -97,14 +98,14 @@ pub struct Run {
     pub retries: Option<usize>,
 }
 
-impl Root {
+impl Input {
     /// Get the args to be passed to the executable itself (not `cargo`).
-    pub fn cargo_options(&self) -> &[String] {
+    pub fn cargo_opts(&self) -> &[String] {
         self.split_args().0
     }
 
     /// Get the args to be passed to the executable itself (not `cargo`).
-    pub fn executable_args(&self) -> &[String] {
+    pub fn exe_args(&self) -> &[String] {
         self.split_args().1
     }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,36 +1,123 @@
-use clap::{AppSettings, Args, Parser, ValueEnum};
+// TODO: docstrings for everything!!!
 
-#[derive(Parser)]
-#[clap(name = "cargo")]
-#[clap(bin_name = "cargo")]
-pub enum Cargo {
-    #[clap(name = "3ds")]
-    Input(Input),
+use clap::{Args, Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(name = "cargo")]
+#[command(bin_name = "cargo")]
+pub enum Command {
+    #[command(name = "3ds")]
+    Root(Root),
 }
 
-#[derive(Args)]
-#[clap(about)]
-#[clap(global_setting(AppSettings::AllowLeadingHyphen))]
-pub struct Input {
-    #[clap(value_enum)]
+#[derive(Args, Debug)]
+#[command(version, about)]
+pub struct Root {
+    /// The cargo command to run. This command will be forwarded to the real
+    /// `cargo` with the appropriate arguments for a 3DS executable.
+    #[command(subcommand)]
     pub cmd: CargoCommand,
-    pub cargo_opts: Vec<String>,
+
+    /// Don't actually run any commands, just echo them to the console.
+    /// This is mostly intended for testing.
+    #[arg(hide = true)]
+    pub dry_run: bool,
+
+    /// Pass additional options through to the `cargo` command.
+    ///
+    /// To pass flags that start with `-`, you must use `--` to separate `cargo 3ds`
+    /// options from cargo options. All args after `--` will be passed through
+    /// to cargo unmodified.
+    ///
+    /// If one of the arguments is itself `--`, the args following that will be
+    /// considered as args to pass to the executable, rather than to `cargo`
+    /// (only works for the `run` or `test` commands). For example, if you want
+    /// to pass some args to the executable directly it might look like this:
+    ///
+    /// > cargo 3ds run -- -- arg1 arg2
+    #[arg(trailing_var_arg = true)]
+    #[arg(global = true)]
+    cargo_options: Vec<String>,
 }
 
-#[derive(ValueEnum, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Subcommand, Debug)]
 pub enum CargoCommand {
+    /// Builds an executable suitable to run on a 3DS (3dsx).
     Build,
-    Run,
-    Test,
+    /// Equivalent to `cargo check`.
     Check,
+    /// Equivalent to `cargo clippy`.
     Clippy,
+    /// Equivalent to `cargo doc`.
+    Doc,
+    /// Builds an executable and sends it to a device with `3dslink`.
+    Run(Run),
+    /// Builds a test executable and sends it to a device with `3dslink`.
+    ///
+    /// This can be used with `--test` for integration tests, or `--lib` for
+    /// unit tests (which require a custom test runner).
+    Test(Test),
+    // TODO: this doesn't seem to work for some reason...
+    #[command(external_subcommand)]
+    Other(Vec<String>),
 }
 
-impl CargoCommand {
-    pub fn should_build_3dsx(&self) -> bool {
-        matches!(
-            self,
-            CargoCommand::Build | CargoCommand::Run | CargoCommand::Test
-        )
+#[derive(Args, Debug)]
+pub struct Test {
+    /// If set, the built executable will not be sent to the device to run it.
+    #[arg(long)]
+    pub no_run: bool,
+    #[command(flatten)]
+    pub run_args: Run,
+}
+
+#[derive(Args, Debug)]
+pub struct Run {
+    /// Specify the IP address of the device to send the executable to.
+    ///
+    /// Corresponds to 3dslink's `--address` arg, which defaults to automatically
+    /// finding the device.
+    #[arg(long, short = 'a')]
+    pub address: Option<String>,
+
+    /// Set the 0th argument of the executable when running it. Corresponds to
+    /// 3dslink's `--argv0` argument.
+    #[arg(long, short = '0')]
+    pub argv0: Option<String>,
+
+    /// Start the 3dslink server after sending the executable. Corresponds to
+    /// 3dslink's `--server` argument.
+    #[arg(long, short = 's')]
+    pub server: bool,
+
+    /// Set the number of tries when connecting to the device to send the executable.
+    /// Corresponds to 3dslink's `--retries` argument.
+    // Can't use `short = 'r'` because that would conflict with cargo's `--release/-r`
+    #[arg(long)]
+    pub retries: Option<usize>,
+}
+
+impl Root {
+    /// Get the args to be passed to the executable itself (not `cargo`).
+    pub fn cargo_options(&self) -> &[String] {
+        self.split_args().0
+    }
+
+    /// Get the args to be passed to the executable itself (not `cargo`).
+    pub fn executable_args(&self) -> &[String] {
+        self.split_args().1
+    }
+
+    fn split_args(&self) -> (&[String], &[String]) {
+        if let Some(split) = self.cargo_options.iter().position(|arg| arg == "--") {
+            let split = if &self.cargo_options[split] == "--" {
+                split + 1
+            } else {
+                split
+            };
+            self.cargo_options.split_at(split)
+        } else {
+            (&self.cargo_options[..], &[])
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub fn make_cargo_build_command(cmd: &CargoCmd, message_format: &Option<String>)
         .stdin(Stdio::inherit())
         .stderr(Stdio::inherit());
 
-    dbg!(command)
+    command
 }
 
 /// Finds the sysroot path of the current toolchain
@@ -285,9 +285,16 @@ pub fn build_3dsx(config: &CTRConfig) {
 
 /// Link the generated 3dsx to a 3ds to execute and test using `3dslink`.
 /// This will fail if `3dslink` is not within the running directory or in a directory found in $PATH
-pub fn link(config: &CTRConfig) {
+pub fn link(config: &CTRConfig, cmd: &CargoCmd) {
+    let run_args = match cmd {
+        CargoCmd::Run(run) => run,
+        CargoCmd::Test(test) => &test.run_args,
+        _ => unreachable!(),
+    };
+
     let mut process = Command::new("3dslink")
         .arg(config.path_3dsx())
+        .args(run_args.get_3dslink_args())
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
 use std::{env, io, process};
 
-/// Built a command using [`make_cargo_build_command`] and execute it,
+/// Build a command using [`make_cargo_build_command`] and execute it,
 /// parsing and returning the messages from the spawned process.
 ///
 /// For commands that produce an executable output, this function will build the

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use cargo_3ds::cmd_clap4::Command;
 use cargo_3ds::command::Cargo;
 use cargo_3ds::{
     build_3dsx, build_elf, build_smdh, check_rust_version, get_message_format, get_metadata,
@@ -8,15 +7,13 @@ use clap::Parser;
 use std::process;
 
 fn main() {
-    let Command::Root(cmd) = cargo_3ds::cmd_clap4::Command::parse();
+    check_rust_version();
 
-    dbg!(&cmd);
-    dbg!(cmd.cargo_options());
-    dbg!(cmd.executable_args());
+    let Cargo::Input(mut input) = Cargo::parse();
 
-    // check_rust_version();
-
-    // let Cargo::Input(mut input) = Cargo::parse();
+    dbg!(&input);
+    dbg!(input.cargo_opts());
+    dbg!(input.exe_args());
 
     // let should_link = get_should_link(&mut input);
     // let message_format = get_message_format(&mut input);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use cargo_3ds::cmd_clap4::Command;
 use cargo_3ds::command::Cargo;
 use cargo_3ds::{
     build_3dsx, build_elf, build_smdh, check_rust_version, get_message_format, get_metadata,
@@ -7,34 +8,40 @@ use clap::Parser;
 use std::process;
 
 fn main() {
-    check_rust_version();
+    let Command::Root(cmd) = cargo_3ds::cmd_clap4::Command::parse();
 
-    let Cargo::Input(mut input) = Cargo::parse();
+    dbg!(&cmd);
+    dbg!(cmd.cargo_options());
+    dbg!(cmd.executable_args());
 
-    let should_link = get_should_link(&mut input);
-    let message_format = get_message_format(&mut input);
+    // check_rust_version();
 
-    let (status, messages) = build_elf(input.cmd, &message_format, &input.cargo_opts);
+    // let Cargo::Input(mut input) = Cargo::parse();
 
-    if !status.success() {
-        process::exit(status.code().unwrap_or(1));
-    }
+    // let should_link = get_should_link(&mut input);
+    // let message_format = get_message_format(&mut input);
 
-    if !input.cmd.should_build_3dsx() {
-        return;
-    }
+    // let (status, messages) = build_elf(input.cmd, &message_format, &input.cargo_opts);
 
-    eprintln!("Getting metadata");
-    let app_conf = get_metadata(&messages);
+    // if !status.success() {
+    //     process::exit(status.code().unwrap_or(1));
+    // }
 
-    eprintln!("Building smdh:{}", app_conf.path_smdh().display());
-    build_smdh(&app_conf);
+    // if !input.cmd.should_build_3dsx() {
+    //     return;
+    // }
 
-    eprintln!("Building 3dsx: {}", app_conf.path_3dsx().display());
-    build_3dsx(&app_conf);
+    // eprintln!("Getting metadata");
+    // let app_conf = get_metadata(&messages);
 
-    if should_link {
-        eprintln!("Running 3dslink");
-        link(&app_conf);
-    }
+    // eprintln!("Building smdh:{}", app_conf.path_smdh().display());
+    // build_smdh(&app_conf);
+
+    // eprintln!("Building 3dsx: {}", app_conf.path_3dsx().display());
+    // build_3dsx(&app_conf);
+
+    // if should_link {
+    //     eprintln!("Running 3dslink");
+    //     link(&app_conf);
+    // }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
-use cargo_3ds::command::Cargo;
+use cargo_3ds::command::{Cargo, CargoCmd, Input, Run, Test};
 use cargo_3ds::{
     build_3dsx, build_elf, build_smdh, check_rust_version, get_message_format, get_metadata,
     get_should_link, link,
 };
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches, Parser};
 use std::process;
 
 fn main() {
@@ -12,10 +12,21 @@ fn main() {
     let Cargo::Input(mut input) = Cargo::parse();
 
     dbg!(&input);
-    dbg!(input.cargo_opts());
-    dbg!(input.exe_args());
 
-    // let should_link = get_should_link(&mut input);
+    let cargo_args = match &input.cmd {
+        CargoCmd::Build(cargo_args)
+        | CargoCmd::Run(Run { cargo_args, .. })
+        | CargoCmd::Test(Test {
+            run_args: Run { cargo_args, .. },
+            ..
+        }) => cargo_args,
+        CargoCmd::Passthrough(other) => todo!(),
+    };
+
+    dbg!(cargo_args.cargo_opts());
+    dbg!(cargo_args.exe_args());
+
+    // let
     // let message_format = get_message_format(&mut input);
 
     // let (status, messages) = build_elf(input.cmd, &message_format, &input.cargo_opts);

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,9 +38,7 @@ fn main() {
     build_3dsx(&app_conf);
 
     if input.cmd.should_link_to_device() {
-        // TODO plumb in exe_args and various 3dslink args
-
         eprintln!("Running 3dslink");
-        link(&app_conf);
+        link(&app_conf, &input.cmd);
     }
 }


### PR DESCRIPTION
Addresses #13 

Leaving this as draft because I want to get some opinions first, but basically with Clap 4 there are some changes which should make it work a lot nicer to pass trailing varargs to `cargo`. This builds off the work @SteveCookTU did to update the CLI and allows us to expose the `3dslink` args mentioned in the issue linked above.

<details>
<summary>Example help text</summary>

```console
$ cargo-3ds help
Usage: cargo <COMMAND>

Commands:
  3ds   Cargo wrapper for developing Rust-based Nintendo 3DS homebrew apps
  help  Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help information
```

```console
$ cargo 3ds help
Cargo wrapper for developing Rust-based Nintendo 3DS homebrew apps

Usage: cargo 3ds [CARGO_OPTIONS]... <COMMAND>

Commands:
  build
          Builds an executable suitable to run on a 3DS (3dsx)
  check
          Equivalent to `cargo check`
  clippy
          Equivalent to `cargo clippy`
  doc
          Equivalent to `cargo doc`
  run
          Builds an executable and sends it to a device with `3dslink`
  test
          Builds a test executable and sends it to a device with `3dslink`
  help
          Print this message or the help of the given subcommand(s)

Arguments:
  [CARGO_OPTIONS]...
          Pass additional options through to the `cargo` command.
          
          To pass flags that start with `-`, you must use `--` to separate `cargo 3ds` options from cargo options. All args after `--` will be passed through to cargo unmodified.
          
          If one of the arguments is itself `--`, the args following that will be considered as args to pass to the executable, rather than to `cargo` (only works for the `run` or `test` commands). For example, if you want to pass some args to the executable
          directly it might look like:
          
          > cargo 3ds run -- -- arg1 arg2

Options:
  -h, --help
          Print help information (use `-h` for a summary)

  -V, --version
          Print version information
```

```console
$ cargo 3ds test --help
Builds a test executable and sends it to a device with `3dslink`.

This can be used with `--test` for integration tests, or `--lib` for unit tests (which require a custom test runner).

Usage: cargo 3ds test [OPTIONS] [CARGO_OPTIONS]...

Arguments:
  [CARGO_OPTIONS]...
          Pass additional options through to the `cargo` command.
          
          To pass flags that start with `-`, you must use `--` to separate `cargo 3ds` options from cargo options. All args after `--` will be passed through to cargo unmodified.
          
          If one of the arguments is itself `--`, the args following that will be considered as args to pass to the executable, rather than to `cargo` (only works for the `run` or `test` commands). For example, if you want to pass some args to the executable
          directly it might look like:
          
          > cargo 3ds run -- -- arg1 arg2

Options:
      --no-run
          If set, the built executable will not be sent to the device to run it

  -a, --address <ADDRESS>
          Specify the IP address of the device to send the executable to.
          
          Corresponds to 3dslink's `--address` arg, which defaults to automatically finding the device.

  -0, --argv0 <ARGV0>
          Set the 0th argument of the executable when running it. Corresponds to 3dslink's `--argv0` argument

  -s, --server
          Start the 3dslink server after sending the executable. Corresponds to 3dslink's `--server` argument

      --retries <RETRIES>
          Set the number of tries when connecting to the device to send the executable. Corresponds to 3dslink's `--retries` argument

  -h, --help
          Print help information (use `-h` for a summary)
```

</details>

<details>
<summary>Dump of debug output when varargs are passed</summary>

```console
$ cargo 3ds run --  --release foo bar
[src/main.rs:13] &cmd = Root {
    cmd: Run(
        Run {
            address: None,
            argv0: None,
            server: false,
            retries: None,
        },
    ),
    cargo_options: [
        "--release",
        "foo",
        "bar",
    ],
}
[src/main.rs:14] cmd.cargo_options() = [
    "--release",
    "foo",
    "bar",
]
[src/main.rs:15] cmd.executable_args() = []
```
```console
$ cargo 3ds test --address 192.168.0.167 -- --test baz 
[src/main.rs:14] &input = Input {
    cmd: Test(
        Test {
            no_run: false,
            run_args: Run {
                address: Some(
                    "192.168.0.167",
                ),
                argv0: None,
                server: false,
                retries: None,
            },
        },
    ),
    dry_run: false,
    cargo_options: [
        "--test",
        "baz",
    ],
}
[src/main.rs:15] input.cargo_opts() = [
    "--test",
    "baz",
]
[src/main.rs:16] input.exe_args() = []
```

</details>

Let me know what y'all think, and if it seems good I'll go ahead and wire up the command parser into the actual logic. After / with this change I was also thinking of adding some CLI tests with `trycmd` or something like that which could print the commands that the tool _would_ run, although it will probably take a bit of mocking and stuff to get that working.