### PR TITLE
Add panic_abort to the build-std list to allow using panic="abort"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub fn make_cargo_build_command(cmd: &CargoCmd, message_format: &Option<String>)
 
     if !sysroot.join("lib/rustlib/armv6k-nintendo-3ds").exists() {
         eprintln!("No pre-build std found, using build-std");
-        command.arg("-Z").arg("build-std");
+        command.arg("-Zbuild-std=panic_abort,std");
     }
 
     let cargo_args = match cmd {


### PR DESCRIPTION
panic_abort allows developers to reduce binary size, but must be built for this target along with std if wanted. This commit allows using this by building the panic_abort crate in addition to the std crate.