### PR TITLE
General refactoring and cargo-new

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See [passthrough arguments](#passthrough-arguments) for more details.
 
 It is also possible to pass any other `cargo` command (e.g. `doc`, `check`),
 and all its arguments will be passed through directly to `cargo` unmodified,
-with the proper `RUSTFLAGS` and `--target` set for the 3DS target.
+with the proper `--target armv6k-nintendo-3ds` set.
 
 ### Basic Examples
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Commands:
           Builds an executable and sends it to a device with `3dslink`
   test
           Builds a test executable and sends it to a device with `3dslink`
+  new
+          Sets up a new cargo project suitable to run on a 3DS
   help
           Print this message or the help of the given subcommand(s)
 
@@ -38,6 +40,7 @@ with the proper `--target armv6k-nintendo-3ds` set.
 * `cargo 3ds check --verbose`
 * `cargo 3ds run --release --example foo`
 * `cargo 3ds test --no-run`
+* `cargo 3ds new my-new-project --edition 2021`
 
 ### Running executables
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -405,7 +405,7 @@ impl Test {
     }
 }
 
-const TOML_CHANGES: &str = "ctru-rs = { git = \"https://github.com/rust3ds/ctru-rs\"}
+const TOML_CHANGES: &str = "ctru-rs = { git = \"https://github.com/rust3ds/ctru-rs\" }
 
 [package.metadata.cargo-3ds]
 romfs_dir = \"romfs\"

--- a/src/command.rs
+++ b/src/command.rs
@@ -124,7 +124,7 @@ pub struct Test {
 
 #[derive(Parser, Debug)]
 pub struct New {
-    /// If set, the built executable will not be sent to the device to run it.
+    /// Path of the new project.
     #[arg(required = true)]
     pub path: String,
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 use cargo_metadata::Message;
 use clap::{Args, Parser, Subcommand};
 
-use crate::{CTRConfig, build_3dsx, build_smdh, get_metadata, link};
+use crate::{build_3dsx, build_smdh, get_metadata, link, CTRConfig};
 
 #[derive(Parser, Debug)]
 #[command(name = "cargo", bin_name = "cargo")]
@@ -46,7 +46,7 @@ pub enum CargoCmd {
     // NOTE: it seems docstring + name for external subcommands are not rendered
     // in help, but we might as well set them here in case a future version of clap
     // does include them in help text.
-    /// Run any other `cargo` command with RUSTFLAGS set for the 3DS.
+    /// Run any other `cargo` command with custom building tailored for the 3DS.
     #[command(external_subcommand, name = "COMMAND")]
     Passthrough(Vec<String>),
 }
@@ -129,7 +129,7 @@ pub struct New {
 }
 
 impl CargoCmd {
-    /// Whether or not this command should compile any code, and thus needs import the custom environment configuration (e.g. RUSTFLAGS, target, std).
+    /// Whether or not this command should compile any code, and thus needs import the custom environment configuration (e.g. target spec).
     pub fn should_compile(&self) -> bool {
         matches!(
             self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,11 +61,6 @@ pub fn run_cargo(cmd: &CargoCmd, message_format: Option<String>) -> (ExitStatus,
 /// Create a cargo command used for building based on the context.
 /// If there is no pre-built std detected in the sysroot, `build-std` is used.
 pub fn make_cargo_build_command(cmd: &CargoCmd, message_format: &Option<String>) -> Command {
-    let rust_flags = env::var("RUSTFLAGS").unwrap_or_default()
-        + &format!(
-            " -L{}/libctru/lib -lctru",
-            env::var("DEVKITPRO").expect("DEVKITPRO is not defined as an environment variable")
-        );
     let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
     let sysroot = find_sysroot();
     let mut command = Command::new(cargo);
@@ -78,7 +73,6 @@ pub fn make_cargo_build_command(cmd: &CargoCmd, message_format: &Option<String>)
     };
 
     command
-        .env("RUSTFLAGS", rust_flags)
         .arg(cmd_str)
         .arg("--target")
         .arg("armv6k-nintendo-3ds")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,16 @@ pub fn make_cargo_command(cmd: &CargoCmd, message_format: &Option<String>) -> Co
         }
     }
 
+    if matches!(cmd, CargoCmd::Test(_)) {
+        // Cargo doesn't like --no-run for doctests:
+        // https://github.com/rust-lang/rust/issues/87022
+        let rustdoc_flags = std::env::var("RUSTDOCFLAGS").unwrap_or_default()
+            // TODO: should we make this output directory depend on profile etc?
+            + " --no-run --persist-doctests target/doctests";
+
+        command.env("RUSTDOCFLAGS", rustdoc_flags);
+    }
+
     let cargo_args = cmd.cargo_args();
 
     command

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use cargo_3ds::command::Cargo;
-use cargo_3ds::{build_3dsx, build_smdh, check_rust_version, get_metadata, link, run_cargo};
+use cargo_3ds::{check_rust_version, run_cargo};
 
 use clap::Parser;
 
@@ -24,21 +24,5 @@ fn main() {
         process::exit(status.code().unwrap_or(1));
     }
 
-    if !input.cmd.should_build_3dsx() {
-        return;
-    }
-
-    eprintln!("Getting metadata");
-    let app_conf = get_metadata(&messages);
-
-    eprintln!("Building smdh:{}", app_conf.path_smdh().display());
-    build_smdh(&app_conf);
-
-    eprintln!("Building 3dsx: {}", app_conf.path_3dsx().display());
-    build_3dsx(&app_conf);
-
-    if input.cmd.should_link_to_device() {
-        eprintln!("Running 3dslink");
-        link(&app_conf, &input.cmd);
-    }
+    input.cmd.run_callback(&messages);
 }


### PR DESCRIPTION
Closes #29
Closes #14 
Would also resolve issues such as: [discussions#127](https://github.com/orgs/rust3ds/discussions/127)

This PR includes support for the `cargo 3ds new` command, as well as a small refactoring of the project needed to implement the new functionality.

List of changes:
- `cargo 3ds new` is now recognized as an official command. Once run for a new directory it will create a new custom project. The differences between `cargo 3ds new` and a standard `cargo new` for now are simple: automatically adds `ctru-rs` (via git repository for now) as a dependency of the project, writes a completely custom `main.rs` which uses the `ctru::prelude` to run a simple "Hello, World!" program, and adds an empty `romfs` folder + Cargo.toml configuration to get RomFS working more easily.
- As my mention of #14 can tell, modifying the `RUSTFLAGS` is now not needed, and that call has been removed. This is thanks to those same changes in the linking mechanism within `rustc` that let us get away with link ordering problems. As such, `libctru` linking isn't specified twice anymore, instead it only depends on the calls within the `ctru-sys` build script.
- Since `cargo-new` is the first subcommand we officially support which does *not* compile any code, many changes have taken place within `cargo-3ds` to ensure more flexibility. Now the cargo arguments are added based on the command and every subcommand can specify an "after-cargo" callback to work with external functionality (e.g. `build` creates the `.3dsx` file in its callback, as well as `new` does its changes there too).

I will update the `ctru-rs` [wiki](https://github.com/rust3ds/ctru-rs/wiki) shortly after this PR merges to briefly explain the new functionality.

With this PR I intend to officially release `cargo-3ds` via [crates.io](https://crates.io). I haven't had any issues with `cargo-3ds` for months now, and the support has only grown bigger. We can start publishing this tool as Rust3DS' first official crate, since its clearly the most mature.

Edit: I forgot to say why I decided not to implement `cargo 3ds init` as well. While it wouldn’t have been hard to implement it the same way as `new`, it posed immense issues in how we would got about actually modifying the context. `cargo-init`, the official one, takes an existing directory and adds to it all the files and config that would normally appear when running `cargo-new`. However, it does not modify existing files that correspond to the project files (e.g. if `src/main.rs` already exists, it skips over its initialisation). This means that by the end of the command, the folder will look more or less exactly as it would after running `new`, but in this case, we aren’t certain that the files present are brand new, and there’s no way of knowing that. Modifying the Cargo.toml or making a custom main.rs replacing the original one would be disastrous. The only way to solve such an issue would be to completely rewrite `cargo-init`, but that seems a bit out of scope for this tool.

