### PR TITLE
Basic CI with lints and cargo-new

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,36 @@
+name: Setup
+description: Set up CI environment for Rust + 3DS development
+
+inputs:
+  toolchain:
+    description: The Rust toolchain to use for the steps
+    required: true
+    default: nightly
+
+runs:
+  using: composite
+  steps:
+    # https://github.com/nektos/act/issues/917#issuecomment-1074421318
+    - if: ${{ env.ACT }}
+      shell: bash
+      name: Hack container for local development
+      run: |
+          curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+          sudo apt-get install -y nodejs
+
+    - name: Setup default Rust toolchain
+      # Use this helper action so we get matcher support
+      # https://github.com/actions-rust-lang/setup-rust-toolchain/pull/15
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        components: clippy, rustfmt, rust-src
+        toolchain: ${{ inputs.toolchain }}
+
+    - name: Install build tools for host
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y build-essential
+
+    - name: Set PATH to include devkitARM
+      shell: bash
+      # For some reason devkitARM/bin is not part of the default PATH in the container
+      run: echo "${DEVKITARM}/bin" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - nightly-2023-01-13
           - nightly
 
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
@@ -50,7 +49,7 @@ jobs:
     container: devkitpro/devkitarm
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,8 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          # Run against a "known good" nightly
-          - nightly-2023-01-13
-          # Check for breakage on latest nightly
-          - nightly
+          - stable
 
-    # But if latest nightly fails, allow the workflow to continue
-    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     runs-on: ubuntu-latest
     container: devkitpro/devkitarm
     steps:
@@ -37,21 +32,11 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
 
-      - name: Hide duplicate warnings from lint job
-        if: ${{ matrix.toolchain == 'nightly' }}
-        run: |
-          echo "::remove-matcher owner=clippy::"
-          echo "::remove-matcher owner=rustfmt::"
-
       - name: Check formatting
         run: cargo fmt --all --verbose -- --check
 
       - name: Cargo check
-        run: cargo 3ds clippy --color=always --verbose --all-targets
-        # --deny=warnings would be nice, but can easily break CI for new clippy
-        # lints getting added. I'd also like to use Github's "inline warnings"
-        # feature, but https://github.com/actions/runner/issues/2341 means we
-        # can't have both that *and* colored output.
+        run: cargo clippy --color=always --verbose --all-targets
 
   project-build:
     strategy:
@@ -59,6 +44,7 @@ jobs:
         toolchain:
           - nightly-2023-01-13
           - nightly
+
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     runs-on: ubuntu-latest
     container: devkitpro/devkitarm
@@ -69,9 +55,6 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           toolchain: ${{ matrix.toolchain }}
-
-      - name: Hide duplicated warnings from lint job
-        run: echo "::remove-matcher owner=clippy::"
       
       - name: Install cargo-3ds
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
     strategy:
       matrix:
         toolchain:
+          # Oldest supported nightly
+          - nightly-2023-05-31
           - nightly
 
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+env:
+  # https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html
+  CARGO_UNSTABLE_SPARSE_REGISTRY: "true"
+  # actions-rust-lang/setup-rust-toolchain sets some default RUSTFLAGS
+  RUSTFLAGS: ""
+
+jobs:
+  lint:
+    strategy:
+      matrix:
+        toolchain:
+          # Run against a "known good" nightly
+          - nightly-2023-01-13
+          # Check for breakage on latest nightly
+          - nightly
+
+    # But if latest nightly fails, allow the workflow to continue
+    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
+    runs-on: ubuntu-latest
+    container: devkitpro/devkitarm
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - uses: ./.github/actions/setup
+        with:
+          toolchain: ${{ matrix.toolchain }}
+
+      - name: Hide duplicate warnings from lint job
+        if: ${{ matrix.toolchain == 'nightly' }}
+        run: |
+          echo "::remove-matcher owner=clippy::"
+          echo "::remove-matcher owner=rustfmt::"
+
+      - name: Check formatting
+        run: cargo fmt --all --verbose -- --check
+
+      - name: Cargo check
+        run: cargo 3ds clippy --color=always --verbose --all-targets
+        # --deny=warnings would be nice, but can easily break CI for new clippy
+        # lints getting added. I'd also like to use Github's "inline warnings"
+        # feature, but https://github.com/actions/runner/issues/2341 means we
+        # can't have both that *and* colored output.
+
+  project-build:
+    strategy:
+      matrix:
+        toolchain:
+          - nightly-2023-01-13
+          - nightly
+    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
+    runs-on: ubuntu-latest
+    container: devkitpro/devkitarm
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - uses: ./.github/actions/setup
+        with:
+          toolchain: ${{ matrix.toolchain }}
+
+      - name: Hide duplicated warnings from lint job
+        run: echo "::remove-matcher owner=clippy::"
+      
+      - name: Install cargo-3ds
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --path .
+
+      - name: Create new project
+        run: cargo 3ds new app --bin
+      
+      - name: Build project
+        working-directory: ./app
+        run: cargo 3ds build --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         toolchain:
           # Oldest supported nightly
-          - nightly-2023-05-31
+          - nightly-2023-06-01
           - nightly
 
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-3ds"
 version = "0.1.0"
 authors = [ "Rust3DS Org", "Andrea Ciliberti <meziu210@icloud.com>" ]
-description = "Cargo wrapper for developing Rust-based Nintendo 3DS homebrew apps"
+description = "Cargo wrapper for developing Nintendo 3DS homebrew apps"
 repository = "https://github.com/Meziu/cargo-3ds"
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub fn check_rust_version() {
     }
 
     let old_version = MINIMUM_RUSTC_VERSION
-        >= Version {
+        > Version {
             // Remove `-nightly` pre-release tag for comparison.
             pre: semver::Prerelease::EMPTY,
             ..rustc_version.semver.clone()
@@ -146,7 +146,7 @@ pub fn check_rust_version() {
         None => false,
         Some(date) => {
             MINIMUM_COMMIT_DATE
-                >= CommitDate::parse(&date).expect("could not parse `rustc --version` commit date")
+                > CommitDate::parse(&date).expect("could not parse `rustc --version` commit date")
         }
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub fn check_rust_version() {
     }
 
     let old_version = MINIMUM_RUSTC_VERSION
-        > Version {
+        >= Version {
             // Remove `-nightly` pre-release tag for comparison.
             pre: semver::Prerelease::EMPTY,
             ..rustc_version.semver.clone()
@@ -146,7 +146,7 @@ pub fn check_rust_version() {
         None => false,
         Some(date) => {
             MINIMUM_COMMIT_DATE
-                > CommitDate::parse(&date).expect("could not parse `rustc --version` commit date")
+                >= CommitDate::parse(&date).expect("could not parse `rustc --version` commit date")
         }
     };
 


### PR DESCRIPTION
Closes #33 

This PR adds a simple CI (somewhat copied over from [`ctru-rs`](https://github.com/rust3ds/ctru-rs/tree/master/.github)).

The CI runs lint checks via clippy (on a unmodified `stable` rust toolchain) and then creates an example program thanks to the new functionality added in #36.