### PR TITLE
Revert RUSTFLAGS removal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub fn run_cargo(cmd: &CargoCmd, message_format: Option<String>) -> (ExitStatus,
 /// if there is no pre-built std detected in the sysroot, `build-std` will be used instead.
 pub fn make_cargo_command(cmd: &CargoCmd, message_format: &Option<String>) -> Command {
     let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+
     let mut command = Command::new(cargo);
 
     command.arg(cmd.subcommand_name());
@@ -67,7 +68,14 @@ pub fn make_cargo_command(cmd: &CargoCmd, message_format: &Option<String>) -> Co
     // Any command that needs to compile code will run under this environment.
     // Even `clippy` and `check` need this kind of context, so we'll just assume any other `Passthrough` command uses it too.
     if cmd.should_compile() {
+        let rust_flags = env::var("RUSTFLAGS").unwrap_or_default()
+            + &format!(
+                " -L{}/libctru/lib -lctru",
+                env::var("DEVKITPRO").expect("DEVKITPRO is not defined as an environment variable")
+            );
+
         command
+            .env("RUSTFLAGS", rust_flags)
             .arg("--target")
             .arg("armv6k-nintendo-3ds")
             .arg("--message-format")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,6 @@ pub fn make_cargo_command(cmd: &CargoCmd, message_format: &Option<String>) -> Co
     let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
 
     let mut command = Command::new(cargo);
-
     command.arg(cmd.subcommand_name());
 
     // Any command that needs to compile code will run under this environment.


### PR DESCRIPTION
After my changes to the RUSTFLAGS before 0.1.0, I had tested ctru-rs to ensure known-to-not-work examples would in fact compile. However, I mistakenly did not test network-related examples, and I know notice that those RUSTFLAGS changes are required to link all network related functions.

```bash
= note: /opt/devkitpro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/bin/ld: /Users/andreaciliberti/Desktop/Programming/Rust/rust-3ds/ctru-rs/target/armv6k-nintendo-3ds/debug/deps/libstd-2aab5dc9bae7bd35.rlib(std-2aab5dc9bae7bd35.std.b2cd8dee9fb32859-cgu.14.rcgu.o): in function `std::sys::unix::net::cvt_gai':
          /Users/andreaciliberti/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys/unix/net.rs:49: undefined reference to `gai_strerror'
          /opt/devkitpro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/bin/ld: /Users/andreaciliberti/Desktop/Programming/Rust/rust-3ds/ctru-rs/target/armv6k-nintendo-3ds/debug/deps/libstd-2aab5dc9bae7bd35.rlib(std-2aab5dc9bae7bd35.std.b2cd8dee9fb32859-cgu.14.rcgu.o): in function `std::sys::unix::net::Socket::recv_with_flags':
          /Users/andreaciliberti/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys/unix/net.rs:247: undefined reference to `recv'
          /opt/devkitpro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/bin/ld: /Users/andreaciliberti/Desktop/Programming/Rust/rust-3ds/ctru-rs/target/armv6k-nintendo-3ds/debug/deps/libstd-2aab5dc9bae7bd35.rlib(std-2aab5dc9bae7bd35.std.b2cd8dee9fb32859-cgu.14.rcgu.o): in function `std::sys::unix::net::Socket::shutdown':
          /Users/andreaciliberti/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys/unix/net.rs:385: undefined reference to `shutdown'
          /opt/devkitpro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/bin/ld: /Users/andreaciliberti/Desktop/Programming/Rust/rust-3ds/ctru-rs/target/armv6k-nintendo-3ds/debug/deps/libstd-2aab5dc9bae7bd35.rlib(std-2aab5dc9bae7bd35.std.b2cd8dee9fb32859-cgu.14.rcgu.o): in function `std::sys::unix::net::Socket::set_nonblocking':
          /Users/andreaciliberti/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys/unix/net.rs:460: undefined reference to `ioctl'
          /opt/devkitpro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/bin/ld: /Users/andreaciliberti/Desktop/Programming/Rust/rust-3ds/ctru-rs/target/armv6k-nintendo-3ds/debug/deps/libstd-2aab5dc9bae7bd35.rlib(std-2aab5dc9bae7bd35.std.b2cd8dee9fb32859-cgu.14.rcgu.o): in function `std::sys::unix::net::Socket::accept::{{closure}}':
          /Users/andreaciliberti/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys/unix/net.rs:232: undefined reference to `accept'
          /opt/devkitpro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/bin/ld: /Users/andreaciliberti/Desktop/Programming/Rust/rust-3ds/ctru-rs/target/armv6k-nintendo-3ds/debug/deps/libstd-2aab5dc9bae7bd35.rlib(std-2aab5dc9bae7bd35.std.b2cd8dee9fb32859-cgu.14.rcgu.o): in function `std::sys_common::net::setsockopt':
          /Users/andreaciliberti/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys_common/net.rs:68: undefined reference to `setsockopt'
          /opt/devkitpro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/bin/ld: /Users/andreaciliberti/Desktop/Programming/Rust/rust-3ds/ctru-rs/target/armv6k-nintendo-3ds/debug/deps/libstd-2aab5dc9bae7bd35.rlib(std-2aab5dc9bae7bd35.std.b2cd8dee9fb32859-cgu.14.rcgu.o): in function `<std::sys_common::net::LookupHost as core::ops::drop::Drop>::drop':
          /Users/andreaciliberti/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys_common/net.rs:171: undefined reference to `freeaddrinfo'
          /opt/devkitpro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/bin/ld: /Users/andreaciliberti/Desktop/Programming/Rust/rust-3ds/ctru-rs/target/armv6k-nintendo-3ds/debug/deps/libstd-2aab5dc9bae7bd35.rlib(std-2aab5dc9bae7bd35.std.b2cd8dee9fb32859-cgu.14.rcgu.o): in function `<std::sys_common::net::LookupHost as core::convert::TryFrom<(&str,u16)>>::try_from::{{closure}}':
          /Users/andreaciliberti/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys_common/net.rs:206: undefined reference to `getaddrinfo'
          /opt/devkitpro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/bin/ld: /Users/andreaciliberti/Desktop/Programming/Rust/rust-3ds/ctru-rs/target/armv6k-nintendo-3ds/debug/deps/libstd-2aab5dc9bae7bd35.rlib(std-2aab5dc9bae7bd35.std.b2cd8dee9fb32859-cgu.14.rcgu.o): in function `std::sys_common::net::TcpStream::write':
          /Users/andreaciliberti/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys_common/net.rs:291: undefined reference to `send'
          /opt/devkitpro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/bin/ld: /Users/andreaciliberti/Desktop/Programming/Rust/rust-3ds/ctru-rs/target/armv6k-nintendo-3ds/debug/deps/libstd-2aab5dc9bae7bd35.rlib(std-2aab5dc9bae7bd35.std.b2cd8dee9fb32859-cgu.14.rcgu.o): in function `std::sys_common::net::TcpListener::bind':
          /Users/andreaciliberti/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys_common/net.rs:413: undefined reference to `bind'
          /opt/devkitpro/devkitARM/bin/../lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/bin/ld: /Users/andreaciliberti/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys_common/net.rs:428: undefined reference to `listen'
          collect2: error: ld returned 1 exit status
```

I wonder if including these functions in the upstream `newlib` (maybe in a similar way to how the pthread functions are filled) would solve the issue...