### PR TITLE
Add verbose flag to print cargo commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ serde = { version = "1.0.139", features = ["derive"] }
 tee = "0.1.0"
 toml = "0.5.6"
 clap = { version = "4.0.15", features = ["derive", "wrap_help"] }
+shlex = "1.1.0"

--- a/src/command.rs
+++ b/src/command.rs
@@ -18,6 +18,11 @@ pub enum Cargo {
 pub struct Input {
     #[command(subcommand)]
     pub cmd: CargoCmd,
+
+    /// Print the exact commands `cargo-3ds` is running. Note that this does not
+    /// set the verbose flag for cargo itself.
+    #[arg(long, short = 'v')]
+    pub verbose: bool,
 }
 
 /// Run a cargo command. COMMAND will be forwarded to the real
@@ -153,6 +158,10 @@ impl CargoCmd {
                         "--doc".to_string(),
                         "-Z".to_string(),
                         "doctest-xcompile".to_string(),
+                        // doctests don't automatically build the `test` crate,
+                        // so we manually specify it on the command line
+                        "-Z".to_string(),
+                        "build-std=std,test".to_string(),
                     ]);
                 } else {
                     cargo_args.push("--no-run".to_string());
@@ -278,7 +287,7 @@ impl CargoCmd {
     ///
     /// - `cargo 3ds build` and other "build" commands will use their callbacks to build the final `.3dsx` file and link it.
     /// - `cargo 3ds new` and other generic commands will use their callbacks to make 3ds-specific changes to the environment.
-    pub fn run_callback(&self, messages: &[Message]) {
+    pub fn run_callback(&self, messages: &[Message], verbose: bool) {
         // Process the metadata only for commands that have it/use it
         let config = if self.should_build_3dsx() {
             eprintln!("Getting metadata");
@@ -290,9 +299,9 @@ impl CargoCmd {
 
         // Run callback only for commands that use it
         match self {
-            Self::Build(cmd) => cmd.callback(&config),
-            Self::Run(cmd) => cmd.callback(&config),
-            Self::Test(cmd) => cmd.callback(&config),
+            Self::Build(cmd) => cmd.callback(&config, verbose),
+            Self::Run(cmd) => cmd.callback(&config, verbose),
+            Self::Test(cmd) => cmd.callback(&config, verbose),
             Self::New(cmd) => cmd.callback(),
             _ => (),
         }
@@ -327,12 +336,12 @@ impl Build {
     /// Callback for `cargo 3ds build`.
     ///
     /// This callback handles building the application as a `.3dsx` file.
-    fn callback(&self, config: &CTRConfig) {
-        eprintln!("Building smdh:{}", config.path_smdh().display());
-        build_smdh(config);
+    fn callback(&self, config: &CTRConfig, verbose: bool) {
+        eprintln!("Building smdh: {}", config.path_smdh().display());
+        build_smdh(config, verbose);
 
         eprintln!("Building 3dsx: {}", config.path_3dsx().display());
-        build_3dsx(config);
+        build_3dsx(config, verbose);
     }
 }
 
@@ -381,12 +390,12 @@ impl Run {
     /// Callback for `cargo 3ds run`.
     ///
     /// This callback handles launching the application via `3dslink`.
-    fn callback(&self, config: &CTRConfig) {
+    fn callback(&self, config: &CTRConfig, verbose: bool) {
         // Run the normal "build" callback
-        self.build_args.callback(config);
+        self.build_args.callback(config, verbose);
 
         eprintln!("Running 3dslink");
-        link(config, self);
+        link(config, self, verbose);
     }
 }
 
@@ -394,13 +403,13 @@ impl Test {
     /// Callback for `cargo 3ds test`.
     ///
     /// This callback handles launching the application via `3dslink`.
-    fn callback(&self, config: &CTRConfig) {
+    fn callback(&self, config: &CTRConfig, verbose: bool) {
         if self.no_run {
             // If the tests don't have to run, use the "build" callback
-            self.run_args.build_args.callback(config)
+            self.run_args.build_args.callback(config, verbose)
         } else {
             // If the tests have to run, use the "run" callback
-            self.run_args.callback(config)
+            self.run_args.callback(config, verbose)
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,11 +18,11 @@ fn main() {
         }
     };
 
-    let (status, messages) = run_cargo(&input.cmd, message_format);
+    let (status, messages) = run_cargo(&input, message_format);
 
     if !status.success() {
         process::exit(status.code().unwrap_or(1));
     }
 
-    input.cmd.run_callback(&messages);
+    input.cmd.run_callback(&messages, input.verbose);
 }


### PR DESCRIPTION
I often find myself wanting to reproduce the same command that `cargo-3ds` was running, so I thought it would be handy to print these commands out when a flag is passed in.

The output looks like this, with the intention that it can be copy-pasted back into the shell easily to run the same command:
```console
$ cargo 3ds -v test
No pre-build std found, using build-std
Running command:
   RUSTDOCFLAGS=" --no-run --persist-doctests target/doctests" \
   RUSTFLAGS=" -L/opt/devkitpro/libctru/lib -lctru" \
   /Users/ianchamberlain/.rustup/toolchains/nightly-x86_64-apple-darwin/bin/cargo test --target armv6k-nintendo-3ds --message-format json-render-diagnostics -Z build-std --no-run

    Finished test [unoptimized + debuginfo] target(s) in 0.26s
Getting metadata
Building smdh:/Users/ianchamberlain/Documents/Development/3ds/test-runner-3ds/target/armv6k-nintendo-3ds/debug/deps/integration-86fc0175e918598b.smdh
Running command:
   smdhtool --create integration "Homebrew Application" "Unspecified Author" /opt/devkitpro/libctru/default_icon.png /Users/ianchamberlain/Documents/Development/3ds/test-runner-3ds/target/armv6k-nintendo-3ds/debug/deps/integration-86fc0175e918598b.smdh

Building 3dsx: /Users/ianchamberlain/Documents/Development/3ds/test-runner-3ds/target/armv6k-nintendo-3ds/debug/deps/integration-86fc0175e918598b.3dsx
Running command:
   3dsxtool /Users/ianchamberlain/Documents/Development/3ds/test-runner-3ds/target/armv6k-nintendo-3ds/debug/deps/integration-86fc0175e918598b.elf /Users/ianchamberlain/Documents/Development/3ds/test-runner-3ds/target/armv6k-nintendo-3ds/debug/deps/integration-86fc0175e918598b.3dsx "--smdh=/Users/ianchamberlain/Documents/Development/3ds/test-runner-3ds/target/armv6k-nintendo-3ds/debug/deps/integration-86fc0175e918598b.smdh"

Running 3dslink
Running command:
   3dslink /Users/ianchamberlain/Documents/Development/3ds/test-runner-3ds/target/armv6k-nintendo-3ds/debug/deps/integration-86fc0175e918598b.3dsx

No response from 3DS!
```


Also fix minor issue with building `test` crate for doctests.