### PR TITLE
Improve cargo 3ds new

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         toolchain:
           # Oldest supported nightly
-          - nightly-2023-06-01
+          - nightly-2024-02-18
           - nightly
 
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ serde = { version = "1.0.139", features = ["derive"] }
 tee = "0.1.0"
 toml = "0.5.6"
 clap = { version = "4.0.15", features = ["derive", "wrap_help"] }
-shlex = "1.1.0"
+shlex = "1.3.0"
 serde_json = "1.0.108"

--- a/src/command.rs
+++ b/src/command.rs
@@ -555,9 +555,11 @@ impl New {
         let toml_path = project_path.join("Cargo.toml");
         let romfs_path = project_path.join("romfs");
         let main_rs_path = project_path.join("src/main.rs");
+        let dummy_romfs_path = romfs_path.join("PUT_YOUR_ROMFS_FILES_HERE.txt");
 
-        // Create the "romfs" directory
+        // Create the "romfs" directory, and place a dummy file within it.
         fs::create_dir(romfs_path).unwrap();
+        fs::File::create(dummy_romfs_path).unwrap();
 
         // Read the contents of `Cargo.toml` to a string
         let mut buf = String::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,8 +215,8 @@ pub fn find_sysroot() -> PathBuf {
 pub fn check_rust_version(input: &Input) {
     let rustc_version = rustc_version::version_meta().unwrap();
 
-    // If the channel isn't nightly, we can't make use the required unstable tools.
-    // However, `cargo new` doesn't have these requirements.
+    // If the channel isn't nightly, we can't make use of the required unstable tools.
+    // However, `cargo 3ds new` doesn't have these requirements.
     if rustc_version.channel > Channel::Nightly && input.cmd.should_compile() {
         eprintln!("building with cargo-3ds requires a nightly rustc version.");
         eprintln!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,10 @@ use cargo_3ds::{check_rust_version, run_cargo};
 use clap::Parser;
 
 fn main() {
-    check_rust_version();
-
     let Cargo::Input(mut input) = Cargo::parse();
+
+    // Depending on the command, we might have different base requirements for the Rust version.
+    check_rust_version(&input);
 
     let message_format = match input.cmd.extract_message_format() {
         Ok(fmt) => fmt,


### PR DESCRIPTION
Based on the discussion in #51.

With these changes, `cargo 3ds new` can be run without a nightly toolchain. It also puts a dummy file within the newly built `romfs` folder to ensure a proper git commit configuration.

Furthermore, `shlex` had some pretty important security updates so I bumped the requirements and the minimum rust nightly used in the CI has been bumped to stay in line with `ctru-rs` (failed builds under 1.73).