### PR TITLE
Build multiple 3DSX files (one per cargo artifact)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ categories = ["command-line-utilities", "development-tools::cargo-plugins"]
 exclude = [".github"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.79"
 
 [dependencies]
 cargo_metadata = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["command-line-utilities", "development-tools::cargo-plugins"]
 exclude = [".github"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.79"
 
 [dependencies]
 cargo_metadata = "0.14.0"

--- a/src/command.rs
+++ b/src/command.rs
@@ -302,7 +302,13 @@ impl CargoCmd {
     /// - `cargo 3ds build` and other "build" commands will use their callbacks to build the final `.3dsx` file and link it.
     /// - `cargo 3ds new` and other generic commands will use their callbacks to make 3ds-specific changes to the environment.
     pub fn run_callbacks(&self, messages: &[Message], metadata: &Option<Metadata>) {
-        let mut configs = Vec::new();
+        let max_artifact_count = if let Some(metadata) = metadata {
+            metadata.packages.iter().map(|pkg| pkg.targets.len()).sum()
+        } else {
+            0
+        };
+
+        let mut configs = Vec::with_capacity(max_artifact_count);
 
         // Process the metadata only for commands that have it/use it
         if self.should_build_3dsx() {

--- a/src/command.rs
+++ b/src/command.rs
@@ -318,13 +318,13 @@ impl CargoCmd {
 
         let config = match self {
             // If we produced one executable, we will attempt to run that one
-            _ if configs.len() == 1 => &configs[0],
+            _ if configs.len() == 1 => configs.remove(0),
 
             // --no-run can produce any number of executables
             Self::Test(Test { no_run: true, .. }) => return,
 
             // Config is ignored by the New callback, using default is fine
-            Self::New(_) => &CTRConfig::default(),
+            Self::New(_) => CTRConfig::default(),
 
             // Otherwise, print an error and exit
             _ => {
@@ -338,7 +338,7 @@ impl CargoCmd {
             }
         };
 
-        self.run_callback(config);
+        self.run_callback(&config);
     }
 
     /// Generate a .3dsx for every executable artifact within the workspace that

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@ pub fn get_artifact_config(package: Package, artifact: Artifact) -> CTRConfig {
         _ => artifact.target.name,
     };
 
-    // TODO: need to break down by target kind and name, e.g.
+    // TODO(#62): need to break down by target kind and name, e.g.
     // [package.metadata.cargo-3ds.example.hello-world]
     // Probably fall back to top level as well.
     let config = package
@@ -413,8 +413,8 @@ impl CTRConfig {
             Self::DEFAULT_AUTHOR.to_string()
         };
 
-        let icon_path = self.icon_path().unwrap_or_else(|err| {
-            eprintln!("Icon at {err} does not exist");
+        let icon_path = self.icon_path().unwrap_or_else(|err_path| {
+            eprintln!("Icon at {err_path} does not exist");
             process::exit(1);
         });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,11 +18,16 @@ fn main() {
         }
     };
 
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .no_deps()
+        .exec()
+        .unwrap();
+
     let (status, messages) = run_cargo(&input, message_format);
 
     if !status.success() {
         process::exit(status.code().unwrap_or(1));
     }
 
-    input.cmd.run_callback(&messages);
+    input.cmd.run_callback(&messages, &metadata);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,11 @@ fn main() {
         }
     };
 
-    let metadata = cargo_metadata::MetadataCommand::new()
-        .no_deps()
-        .exec()
-        .unwrap();
+    let metadata = if input.cmd.should_build_3dsx() {
+        cargo_metadata::MetadataCommand::new().no_deps().exec().ok()
+    } else {
+        None
+    };
 
     let (status, messages) = run_cargo(&input, message_format);
 
@@ -29,5 +30,5 @@ fn main() {
         process::exit(status.code().unwrap_or(1));
     }
 
-    input.cmd.run_callback(&messages, &metadata);
+    input.cmd.run_callbacks(&messages, &metadata);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,13 @@ fn main() {
     };
 
     let metadata = if input.cmd.should_build_3dsx() {
-        cargo_metadata::MetadataCommand::new().no_deps().exec().ok()
+        match cargo_metadata::MetadataCommand::new().no_deps().exec() {
+            Ok(metadata) => Some(metadata),
+            Err(err) => {
+                eprintln!("Warning: failed to gather cargo metadata for the project: {err}");
+                None
+            }
+        }
     } else {
         None
     };
@@ -30,5 +36,5 @@ fn main() {
         process::exit(status.code().unwrap_or(1));
     }
 
-    input.cmd.run_callbacks(&messages, &metadata);
+    input.cmd.run_callbacks(&messages, metadata.as_ref());
 }


### PR DESCRIPTION
Closes #44

Trying again for #58 ! I think this is a bit cleaner / less churn vs what I had there.

Two main components here:
- Make `CTRConfig` implement `Deserialize`, and use that to parse metadata instead of manually walking the `Cargo.toml`. We already collected the metadata once, so we can just pass it through everywhere.
- Run build callbacks once per artifact instead of just once. After all build callbacks are done, then try to run any additional callbacks, failing if we were asked to run more than one executable / test.

TODOs:
- [x] ~~Maybe if a custom runner for `cargo 3ds test` is specified, we should do the normal cargo thing and run all the executables in sequence? This would be nice for our CI etc.~~
  Nvm, I forgot that for custom runner Cargo does the running, not `cargo-3ds`. I should file a separate issue to see if we can build the 3dsx before invoking the runner though... #61 
- [ ] Allow customizing the metadata for individual artifacts like I planned in #44 – might do this as a separate PR since this already feels big.
- [x] Some small cleanup things