### PR TITLE
Use artifact.test to determine if an executable is a test one

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ pub(crate) fn get_artifact_config(package: Package, artifact: Artifact) -> CTRCo
     // For now, assume a single "kind" per artifact. It seems to be the case
     // when a single executable is built anyway but maybe not in all cases.
     let name = match artifact.target.kind[0].as_ref() {
-        "bin" | "lib" | "rlib" | "dylib" if artifact.target.test => {
+        "bin" | "lib" | "rlib" | "dylib" if artifact.profile.test => {
             format!("{} tests", artifact.target.name)
         }
         "example" => {


### PR DESCRIPTION
`artifact.target.test` seems to only tell if the executable _has_ tests, not whether it _is_ a test executable

This was causing ordinary executables to be named as if they were tests